### PR TITLE
Use slack-winston transport for winston error logs

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rsync -r --delete-after --quiet $TRAVIS_BUILD_DIR johnny-5@138.197.20.170:
-ssh johnny-5@138.197.20.170 "cd devanoobot && npm run migrations:prod && ../.npm-global/bin/pm2 restart devanoobot.config.json --update-env"
+ssh johnny-5@138.197.20.170 "cp .devanoobot_env devanoobot/.env && cd devanoobot && npm run migrations:prod && ../.npm-global/bin/pm2 restart devanoobot.config.json --update-env"

--- a/index.js
+++ b/index.js
@@ -5,6 +5,14 @@ const _ = require('lodash')
 const bot = require('express')()
 const body_parser = require('body-parser')
 const winston = require('winston')
+const slack_winston = require('slack-winston').Slack
+winston.add(slack_winston, {
+  domain: 'devanooga',
+  token: process.env.SLACK_VERIFICATION_TOKEN,
+  webhook_url: process.env.SLACK_LOGS_WEBHOOK_URL,
+  channel: 'devanoobot_logs',
+  level: 'error',
+})
 
 // Register body parser.
 bot.use(body_parser.json())


### PR DESCRIPTION
This PR adds a `winston` transport for error level messages to get posted to the `#devanoobot_logs` channel on Slack.